### PR TITLE
【Fixxed】rails g の際に不要ファイルが作成されないように対応

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module GitMofmof
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
config/application.rb に下記を追加

module YourApp
  class Application < Rails::Application
    #...
    **config.generators do |g|
      g.assets     false
      g.helper     false**
    end
    #...
  end